### PR TITLE
narrow scope of `@match` clause

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -4,7 +4,7 @@
 // @version      0.5
 // @description  Return of the YouTube Dislike, Based off https://www.returnyoutubedislike.com/
 // @author       Anarios & JRWR
-// @match      *://www.youtube.com/watch*
+// @match      *://*.youtube.com/watch*
 // @compatible chrome
 // @compatible firefox
 // @compatible opera

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -4,8 +4,7 @@
 // @version      0.5
 // @description  Return of the YouTube Dislike, Based off https://www.returnyoutubedislike.com/
 // @author       Anarios & JRWR
-// @match        *://*.youtube.com/*
-// @include      *://*.youtube.com/*
+// @match      *://www.youtube.com/watch*
 // @compatible chrome
 // @compatible firefox
 // @compatible opera


### PR DESCRIPTION
This restricts the userscript to only load on `*://*.youtube.com/watch*`, which prevents it from loading on pages where it is unnecessary. 